### PR TITLE
Updated imshow for images already in row-major order

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -408,6 +408,28 @@ for f in (:pcolor, :pcolormesh)
 end
 
 ###########################################################################
+# Allow imshow to images that are already in row-major order in Julia
+
+function imshow{T}(img::AbstractArray{T,3}, args...; kws...)
+    dim1 = size(img)[1]
+    dim1 == 3 || dim1 == 4 ? imshow(PyObject(img, true), args..., kws...) :
+                             imshow(PyObject(img), args...; kws...)
+end
+
+try
+    if isa(Main.Images, Module)
+        # Define imshow for images
+        global imshow
+        Images = Main.Images
+        function imshow{T}(img::Main.Images.AbstractImageDirect{T,3}, args...; kws...)
+            Images.colordim(img) == 1 ? imshow(PyCall.PyObject(Images.data(img), true), args..., kws...) :
+                                        imshow(PyCall.PyObject(Images.data(img)), args...; kws...)
+        end
+    end
+end
+
+
+###########################################################################
 
 include("latex.jl")
 

--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -421,10 +421,14 @@ try
         # Define imshow for images
         global imshow
         Images = Main.Images
-        function imshow{T}(img::Main.Images.AbstractImageDirect{T,3}, args...; kws...)
+
+        imshow{T}(img::Main.Images.AbstractImageDirect{T,3}, args...; kws...) =
             Images.colordim(img) == 1 ? imshow(PyCall.PyObject(Images.data(img), true), args..., kws...) :
                                         imshow(PyCall.PyObject(Images.data(img)), args...; kws...)
-        end
+
+        imshow{T}(img::Main.Images.AbstractImageDirect{T,2}, args...; kws...) =
+            Images.spatialorder(img)[1] == "x" ? imshow(PyCall.PyObject(Images.data(img), true), args..., kws...) :
+                                                 imshow(PyCall.PyObject(Images.data(img)), args...; kws...)
     end
 end
 


### PR DESCRIPTION
Frequently, images in Julia are already in row-major order, in which case the color dimension is first.  This PR reverses the passed in array metadata so that the color dimension is last, without modifying the image array.

It also adds an imshow function for `Image` types if the `Images` module is loaded.

Depends on https://github.com/stevengj/PyCall.jl/pull/85, which needs to be merged first, tagged, and then `REQUIRES` should be updated here to that version of `PyCall`.
