### PR TITLE
Switch to PyQt5 instead of PyQt4 when using conda

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -134,7 +134,7 @@ function find_backend(matplotlib::PyObject)
                 if defaultgui == :qt_pyside
                     pyimport_conda("PySide", "pyside")
                 else
-                    pyimport_conda("PyQt4", "pyqt")
+                    pyimport_conda("PyQt5", "pyqt")
                 end
             elseif defaultgui == :wx
                 pyimport_conda("wx", "wxpython")


### PR DESCRIPTION
I have no idea whether this is sufficient to fix #242 -
at least the error goes away on `using PyPlot` now,
but don't know if it's really working properly

Also no idea what impact this has on people who've been using PyQt4 in an existing install with Conda.jl, will it auto-upgrade?