### PR TITLE
Revert "Switch to PyQt5 instead of PyQt4 when using conda"

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -134,7 +134,7 @@ function find_backend(matplotlib::PyObject)
                 if defaultgui == :qt_pyside
                     pyimport_conda("PySide", "pyside")
                 else
-                    pyimport_conda("PyQt5", "pyqt")
+                    pyimport_conda("PyQt4", "pyqt")
                 end
             elseif defaultgui == :wx
                 pyimport_conda("wx", "wxpython")


### PR DESCRIPTION
Reverts JuliaPy/PyPlot.jl#243 since it looks like conda changed their mind and are back to qt4