### PR TITLE
quell type and immutable deprecation warnings under 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.6
 PyCall 1.6.2
 Colors
 LaTeXStrings

--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -11,7 +11,7 @@ using Compat
 @compat import Base.show
 
 # Wrapper around matplotlib Figure, supporting graphics I/O and pretty display
-type Figure
+mutable struct Figure
     o::PyObject
 end
 
@@ -20,7 +20,7 @@ end
 # that lazily looks up help from a PyObject via zero or more keys.
 # This saves us time when loading PyPlot, since we don't have
 # to load up all of the documentation strings right away.
-immutable LazyHelp
+struct LazyHelp
     o::PyObject
     keys::Tuple{Vararg{Compat.String}}
     LazyHelp(o::PyObject) = new(o, ())

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -7,7 +7,7 @@ export ColorMap, get_cmap, register_cmap, get_cmaps
 ########################################################################
 # Wrapper around colors.Colormap type:
 
-type ColorMap
+mutable struct ColorMap
     o::PyObject
 end
 


### PR DESCRIPTION
... and raise the minimum Julia version to 0.6. Best!