### PR TITLE
add support for args and kws to plt.show()

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -175,7 +175,7 @@ end
 
 @doc LazyHelp(plt,"step") step(x, y; kws...) = pycall(plt["step"], PyAny, x, y; kws...)
 
-Base.show(args...; kws...) = begin pycall(plt["show"], PyObject, args...; kws...); nothing; end
+Base.show(; kws...) = begin pycall(plt["show"], PyObject; kws...); nothing; end
 
 close(f::Figure) = close(f[:number])
 function close(f::Integer)

--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -175,7 +175,7 @@ end
 
 @doc LazyHelp(plt,"step") step(x, y; kws...) = pycall(plt["step"], PyAny, x, y; kws...)
 
-Base.show() = begin pycall(plt["show"], PyObject); nothing; end
+Base.show(args...; kws...) = begin pycall(plt["show"], PyObject, args...; kws...); nothing; end
 
 close(f::Figure) = close(f[:number])
 function close(f::Integer)


### PR DESCRIPTION
Matplotlib now (as of I'm not sure when) supports the keyword `block` to `plt.show`, which, when set to `False`, prevents plots from blocking the execution of code in noninteractive mode. See http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.show for more information.

In order to make use of this feature, this PR adds support for passing `args` and `kws` to `plt.show`.