### PR TITLE
fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For example:
 
 ```
 using PyPlot
-x = linspace(0,2*pi,1000); y = sin(3*x + 4*cos(2*x));
+x = linspace(0,2*pi,1000); y = sin.(3 * x + 4 * cos.(2 * x));
 plot(x, y, color="red", linewidth=2.0, linestyle="--")
 title("A sinusoidally modulated sinusoid")
 ```


### PR DESCRIPTION
The current version causes `WARNING: cos{T <: Number}(x::AbstractArray{T}) is deprecated, use cos.(x) instead.`