### PR TITLE
Update mimewritable to showable

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -4,7 +4,7 @@ module PyPlot
 
 using PyCall
 import PyCall: PyObject, pygui, pycall, pyexists
-import Base: convert, ==, isequal, hash, getindex, setindex!, haskey, keys, show, mimewritable
+import Base: convert, ==, isequal, hash, getindex, setindex!, haskey, keys, show, showable
 export Figure, plt, matplotlib, pygui, withfig
 
 using Compat
@@ -78,14 +78,14 @@ for (mime,fmt) in aggformats
         f.o["canvas"]["print_figure"](io, format=$fmt, bbox_inches="tight")
     end
     if fmt != "svg"
-        @eval mimewritable(::MIME{Symbol($mime)}, f::Figure) = !isempty(f) && haskey(pycall(f.o["canvas"]["get_supported_filetypes"], PyDict), $fmt)
+        @eval showable(::MIME{Symbol($mime)}, f::Figure) = !isempty(f) && haskey(pycall(f.o["canvas"]["get_supported_filetypes"], PyDict), $fmt)
     end
 end
 
 # disable SVG output by default, since displaying large SVGs (large datasets)
 # in IJulia is slow, and browser SVG display is buggy.  (Similar to IPython.)
 const SVG = [false]
-mimewritable(::MIME"image/svg+xml", f::Figure) = SVG[1] && !isempty(f) && haskey(pycall(f.o["canvas"]["get_supported_filetypes"], PyDict), "svg")
+showable(::MIME"image/svg+xml", f::Figure) = SVG[1] && !isempty(f) && haskey(pycall(f.o["canvas"]["get_supported_filetypes"], PyDict), "svg")
 svg() = SVG[1]
 svg(b::Bool) = (SVG[1] = b)
 


### PR DESCRIPTION
`mimewritable` is replaced by `showable` in Julia 1.0.