### PR TITLE
fix 0.7 depwarns

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ For example:
 
 ```
 using PyPlot
-x = linspace(0,2*pi,1000); y = sin.(3 * x + 4 * cos.(2 * x));
+# use x = linspace(0,2*pi,1000) in Julia 0.6
+x = range(0; stop=2*pi, length=1000); y = sin.(3 * x + 4 * cos.(2 * x));
 plot(x, y, color="red", linewidth=2.0, linestyle="--")
 title("A sinusoidally modulated sinusoid")
 ```

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -158,7 +158,7 @@ get_cmaps() =
 function show(io::IO, ::MIME"image/svg+xml", cs::AbstractVector{ColorMap})
     n = 256
     nc = length(cs)
-    a = linspace(0,1,n)
+    a = Compat.range(0; stop=1, length=n)
     namelen = mapreduce(c -> length(c[:name]), max, cs)
     width = 0.5
     height = 5

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -63,7 +63,7 @@ ColorMap(name::Union{AbstractString,Symbol},
          g::AbstractVector{Tuple{T,T,T}},
          b::AbstractVector{Tuple{T,T,T}},
          n=max(256,length(r),length(g),length(b)), gamma=1.0) where {T<:Real} =
-    ColorMap(name, r,g,b, Array{Tuple{T,T,T}}(0), n, gamma)
+    ColorMap(name, r,g,b, Array{Tuple{T,T,T}}(undef, 0), n, gamma)
 
 # as above, but also passing an alpha array
 function ColorMap(name::Union{AbstractString,Symbol},
@@ -88,11 +88,11 @@ function ColorMap(name::Union{AbstractString,Symbol},
     if nc == 0
         throw(ArgumentError("ColorMap requires a non-empty Colorant array"))
     end
-    r = Array{Tuple{Float64,Float64,Float64}}(nc)
+    r = Array{Tuple{Float64,Float64,Float64}}(undef, nc)
     g = similar(r)
     b = similar(r)
     a = T <: TransparentColor ?
-        similar(r) : Array{Tuple{Float64,Float64,Float64}}(0)
+        similar(r) : Array{Tuple{Float64,Float64,Float64}}(undef, 0)
     for i = 1:nc
         x = (i-1) / (nc-1)
         if T <: TransparentColor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 ENV["MPLBACKEND"]="agg" # no GUI
 
-using PyPlot, PyCall
+using PyPlot, PyCall, Compat
 
 if isdefined(Base, :Test) && !Base.isdeprecated(Base, :Test)
     using Base.Test
@@ -26,7 +26,7 @@ info("got plot bounding box ", boundingbox)
 @test all([300, 200] .< boundingbox[3:4] - boundingbox[1:2] .< [450,350])
 
 c = get_cmap("viridis")
-a = linspace(0,1,5)
+a = Compat.range(0; stop=1, length=5)
 rgba = pycall(pycall(PyPlot.ScalarMappable, PyObject, cmap=c,
                      norm=PyPlot.Normalize01)["to_rgba"], PyArray, a)
 @test rgba ≈ [ 0.267004  0.004874  0.329415  1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,16 +2,9 @@ ENV["MPLBACKEND"]="agg" # no GUI
 
 using PyPlot, PyCall
 using Compat
+using Compat.Test
 
 VERSION >= v"0.7.0" && using Base64
-
-if isdefined(Base, :Test) && !Base.isdeprecated(Base, :Test)
-    using Base.Test
-else
-    using Test
-end
-
-!isdefined(Base, :Base64) && using Base64
 
 plot(1:5, 2:6, "ro-")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ else
     using Test
 end
 
+!isdefined(Base, :Base64) && using Base64
+
 plot(1:5, 2:6, "ro-")
 
 line = gca()[:lines][1]
@@ -22,7 +24,7 @@ s = stringmime("application/postscript", fig);
 m = match(r"%%BoundingBox: *([0-9]+) +([0-9]+) +([0-9]+) +([0-9]+)", s)
 @test m !== nothing
 boundingbox = map(s -> parse(Int, s), m.captures)
-info("got plot bounding box ", boundingbox)
+Compat.@info("got plot bounding box ", boundingbox)
 @test all([300, 200] .< boundingbox[3:4] - boundingbox[1:2] .< [450,350])
 
 c = get_cmap("viridis")


### PR DESCRIPTION
- Added `undef` to array constructors
- Replaced `linspace` with `range`
    - Also updated README example. Not sure if there is a better way to show both 0.6 and 0.7 syntax.
- Miscellaneous updates to fix depwarns in tests