### PR TITLE
Including view_init and voxels to the list of exported functions for 3D plots

### DIFF
--- a/src/plot3d.jl
+++ b/src/plot3d.jl
@@ -40,7 +40,7 @@ export art3D, Axes3D, using3D, surf, mesh, bar3D, contour3D, contourf3D, plot3D,
 
 const mplot3d_funcs = (:bar3d, :contour3D, :contourf3D, :plot3D, :plot_surface,
                        :plot_trisurf, :plot_wireframe, :scatter3D,
-                       :text2D, :text3D, :view_init)
+                       :text2D, :text3D, :view_init, :voxels)
 
 for f in mplot3d_funcs
     fs = string(f)

--- a/src/plot3d.jl
+++ b/src/plot3d.jl
@@ -40,7 +40,7 @@ export art3D, Axes3D, using3D, surf, mesh, bar3D, contour3D, contourf3D, plot3D,
 
 const mplot3d_funcs = (:bar3d, :contour3D, :contourf3D, :plot3D, :plot_surface,
                        :plot_trisurf, :plot_wireframe, :scatter3D,
-                       :text2D, :text3D)
+                       :text2D, :text3D, :view_init)
 
 for f in mplot3d_funcs
     fs = string(f)


### PR DESCRIPTION
Currently, calling `view_init` to rotate a 3D figure or `voxels` raises an `UndefVarError`. (See [issue 464](https://github.com/JuliaPy/PyPlot.jl/issues/464).)

This issue can be fixed by adding these functions to the list of exported functions in plot3d.jl.