### PR TITLE
replace isjulia_display with function to fix #476 (PackageCompiler)

### DIFF
--- a/src/PyPlot.jl
+++ b/src/PyPlot.jl
@@ -111,7 +111,7 @@ Base.isempty(f::Figure) = isempty(pycall(f."get_axes", PyVector))
 const withfig_fignums = Set{Int}()
 
 function display_figs() # called after IJulia cell executes
-    if isjulia_display[1]
+    if isdisplayok()
         for manager in Gcf."get_all_fig_managers"()
             f = manager."canvas"."figure"
             if f.number ∉ withfig_fignums
@@ -124,7 +124,7 @@ function display_figs() # called after IJulia cell executes
 end
 
 function close_figs() # called after error in IJulia cell
-    if isjulia_display[1]
+    if isdisplayok()
         for manager in Gcf."get_all_fig_managers"()
             f = manager."canvas"."figure"
             if f.number ∉ withfig_fignums
@@ -148,7 +148,7 @@ force_new_fig() = gcf_isnew[1] = true
 end
 
 @doc LazyHelp(orig_gcf) function gcf()
-    if isjulia_display[1] && gcf_isnew[1]
+    if isdisplayok() && gcf_isnew[1]
         return figure()
     else
         return pycall(orig_gcf, PyAny)


### PR DESCRIPTION
As discussed in #476, the pre- and post-execute IJulia hooks do not execute when PyPlot is included in a sysimage generated by PackageCompiler.jl. This is because the global `isjulia_display` is set to false -- @marius311 suggests it's because `__init__` is called too early. This also causes the hooks to not be pushed to IJulia.

This PR makes things work by replacing `isjulia_display` with the function `isdisplayok()`. One must also  manually push the hooks, i.e. you create a sysimage with

```julia
using PackageCompiler
create_sysimage(
   [:IJulia, :PyPlot]; 
    sysimage_path = "sys.dylib",
    script = "script.jl"
)
```

where `script.jl` contains
```julia
using IJulia
using PyPlot

Main.IJulia.push_preexecute_hook(PyPlot.force_new_fig)
Main.IJulia.push_postexecute_hook(PyPlot.display_figs)
Main.IJulia.push_posterror_hook(PyPlot.close_figs)
```

This works but is pretty hacky, so I'd welcome suggestions on how to best solve this.