### PR TITLE
fix for 3d subplots

### DIFF
--- a/src/plot3d.jl
+++ b/src/plot3d.jl
@@ -58,7 +58,11 @@ for f in mplot3d_funcs
     fs = string(f)
     @eval @doc LazyHelp(axes3D,"Axes3D", $fs) function $f(args...; kws...)
         using3D() # make sure mplot3d is loaded
-        ax = PyPlot.version <= v"3.4" ? gca(projection="3d") : plt."subplot"(projection="3d")
+        if PyPlot.version <= v"3.4"
+            ax = gca(projection="3d")
+        else
+            ax = gca()._subplotspec.get_geometry() == (1,1,0,0) ? plt."subplot"(projection="3d") : gca()
+        end
         pycall(ax.$fs, PyAny, args...; kws...)
     end
 end
@@ -74,7 +78,11 @@ for f in zlabel_funcs
     fs = string("set_", f)
     @eval @doc LazyHelp(axes3D,"Axes3D", $fs) function $f(args...; kws...)
         using3D() # make sure mplot3d is loaded
-        ax = PyPlot.version <= v"3.4" ? gca(projection="3d") : plt."subplot"(projection="3d")
+        if PyPlot.version <= v"3.4"
+            ax = gca(projection="3d")
+        else
+            ax = gca()._subplotspec.get_geometry() == (1,1,0,0) ? plt."subplot"(projection="3d") : gca()
+        end
         pycall(ax.$fs, PyAny, args...; kws...)
     end
 end


### PR DESCRIPTION
The current implementation has the problem that it overwrites subplots (see https://github.com/JuliaPy/PyPlot.jl/issues/532). 

One of the problems with finding a good solution is (I believe) that the projection of an existing subplot cannot be easily changed. With this PR, the following works well
```
x = collect(-10:10)
y = collect(-11:11)
z = x.^2 .+ y'.^2

using PyPlot

figure()
subplot(221,projection="3d")
  surf(x, y, z')
  zlim(0,250)
  title("A")
subplot(222,projection="3d")
  surf(x, y, -z')
  zlim(-250,0)
  title("B")

figure()
  #ax = PyPlot.axes(projection="3d")     #works w/wo this
  surf(x, y, z')
  zlim(0,250)
  title("A")
```