### PR TITLE
fix CI on ubuntu

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Install matplotlib
         run: if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get install -y python3-matplotlib; fi
+        shell: bash
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
           - x64
     steps:
       - name: Install matplotlib
-        run: if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get install -y python3-matplotlib); fi
+        run: if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get install -y python3-matplotlib; fi
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
         arch:
           - x64
     steps:
+      - name: Install matplotlib
+        run: test "$RUNNER_OS" == "Linux" && sudo apt-get install -y python3-matplotlib
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
           - x64
     steps:
       - name: Install matplotlib
-        run: (test "$RUNNER_OS" = "Linux" && sudo apt-get install -y python3-matplotlib) || true
+        run: if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get install -y python3-matplotlib); fi
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
           - x64
     steps:
       - name: Install matplotlib
-        run: test "$RUNNER_OS" == "Linux" && sudo apt-get install -y python3-matplotlib
+        run: test "$RUNNER_OS" = "Linux" && sudo apt-get install -y python3-matplotlib
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
           - x64
     steps:
       - name: Install matplotlib
-        run: test "$RUNNER_OS" = "Linux" && sudo apt-get install -y python3-matplotlib
+        run: (test "$RUNNER_OS" = "Linux" && sudo apt-get install -y python3-matplotlib) || true
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
Install Matplotlib manually on Linux, where PyCall defaults to the system `python3`.