### PR TITLE
Fix precompilation on latest master

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -169,6 +169,7 @@ gui = :default
 # initialization -- anything that depends on Python has to go here,
 # so that it occurs at runtime (while the rest of PyPlot can be precompiled).
 function __init__()
+    ccall(:jl_generating_output, Cint, ()) == 1 && return nothing
     isjulia_display[] = isdisplayok()
     copy!(matplotlib, pyimport_conda("matplotlib", "matplotlib"))
     mvers = matplotlib.__version__


### PR DESCRIPTION
Use Revise.jl's "trick" that disables `__init__()` when precompiling.

See: timholy/Revise.jl#731

May not be the most idiomatic or best fix in the long term; perhaps the first call to a PyPlot function could initialize the backend instead? Related to: https://github.com/JuliaPy/PyPlot.jl/pull/480/files

Same as: https://github.com/stevengj/PythonPlot.jl/pull/26