### PR TITLE
Update deprecated colormap APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ colors in various plot types).  In particular:
 
 * `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.cm.ColormapRegistry.get_cmap](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.get_cmap) function.
 
-* `register_cmap(c::ColorMap)` or `register_cmap(name::String, c::ColorMap)` call the [matplotlib.cm.register_cmap](http://matplotlib.org/api/cm_api.html#matplotlib.cm.register_cmap) function.
+* `register_cmap(c::ColorMap)` or `register_cmap(name::String, c::ColorMap)` call the [matplotlib.colormap.register](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.register) function.
 
 * `get_cmaps()` returns a `Vector{ColorMap}` of the currently
   registered colormaps.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ colors in various plot types).  In particular:
 
   * Even more general color maps may be defined by passing arrays of (x,y0,y1) tuples for the red, green, blue, and (optionally) alpha components, as defined by the [matplotlib.colors.LinearSegmentedColormap](http://matplotlib.org/api/colors_api.html#matplotlib.colors.LinearSegmentedColormap) constructor, via: `ColorMap{T<:Real}(name::String, r::AbstractVector{(T,T,T)}, g::AbstractVector{(T,T,T)}, b::AbstractVector{(T,T,T)}, n=256, gamma=1.0)` or `ColorMap{T<:Real}(name::String, r::AbstractVector{(T,T,T)}, g::AbstractVector{(T,T,T)}, b::AbstractVector{(T,T,T)}, alpha::AbstractVector{(T,T,T)}, n=256, gamma=1.0)`
 
-  * `ColorMap(name::String)` returns an existing (registered) colormap, equivalent to [matplotlib.cm.get_cmap](http://matplotlib.org/api/cm_api.html#matplotlib.cm.get_cmap)(`name`).
+  * `ColorMap(name::String)` returns an existing (registered) colormap, equivalent to [matplotlib.cm.ColormapRegistry.get_cmap](http://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.get_cmap)(`name`).
 
   * `matplotlib.colors.Colormap` objects returned by Python functions are automatically converted to the `ColorMap` type.
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ colors in various plot types).  In particular:
 
   * `matplotlib.colors.Colormap` objects returned by Python functions are automatically converted to the `ColorMap` type.
 
-* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.cm.get_cmap](http://matplotlib.org/api/cm_api.html#matplotlib.cm.get_cmap) function.
+* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.cm.ColormapRegistry.get_cmap](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.get_cmap) function.
 
 * `register_cmap(c::ColorMap)` or `register_cmap(name::String, c::ColorMap)` call the [matplotlib.cm.register_cmap](http://matplotlib.org/api/cm_api.html#matplotlib.cm.register_cmap) function.
 

--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ colors in various plot types).  In particular:
 
   * Even more general color maps may be defined by passing arrays of (x,y0,y1) tuples for the red, green, blue, and (optionally) alpha components, as defined by the [matplotlib.colors.LinearSegmentedColormap](http://matplotlib.org/api/colors_api.html#matplotlib.colors.LinearSegmentedColormap) constructor, via: `ColorMap{T<:Real}(name::String, r::AbstractVector{(T,T,T)}, g::AbstractVector{(T,T,T)}, b::AbstractVector{(T,T,T)}, n=256, gamma=1.0)` or `ColorMap{T<:Real}(name::String, r::AbstractVector{(T,T,T)}, g::AbstractVector{(T,T,T)}, b::AbstractVector{(T,T,T)}, alpha::AbstractVector{(T,T,T)}, n=256, gamma=1.0)`
 
-  * `ColorMap(name::String)` returns an existing (registered) colormap, equivalent to [matplotlib.cm.ColormapRegistry.get_cmap](http://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.get_cmap)(`name`).
+  * `ColorMap(name::String)` returns an existing (registered) colormap, equivalent to [matplotlib.pyplot.get_cmap](http://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib-pyplot-get-cmap)(`name`).
 
   * `matplotlib.colors.Colormap` objects returned by Python functions are automatically converted to the `ColorMap` type.
 
-* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.cm.ColormapRegistry.get_cmap](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.get_cmap) function.
+* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.pyplotget_cmap](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib-pyplot-get-cmap) function.
 
 * `register_cmap(c::ColorMap)` or `register_cmap(name::String, c::ColorMap)` call the [matplotlib.colormap.register](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.register) function.
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ colors in various plot types).  In particular:
 
   * `matplotlib.colors.Colormap` objects returned by Python functions are automatically converted to the `ColorMap` type.
 
-* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.pyplotget_cmap](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib-pyplot-get-cmap) function.
+* `get_cmap(name::String)` or `get_cmap(name::String, lut::Integer)` call the [matplotlib.pyplot.get_cmap](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib-pyplot-get-cmap) function.
 
 * `register_cmap(c::ColorMap)` or `register_cmap(name::String, c::ColorMap)` call the [matplotlib.colormap.register](https://matplotlib.org/stable/api/cm_api.html#matplotlib.cm.ColormapRegistry.register) function.
 

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -54,7 +54,7 @@ function init_colormaps()
 
     copy!(LinearSegmentedColormap, colorsm."LinearSegmentedColormap")
 
-    copy!(cm_get_cmap, cm.ColormapRegistry."get_cmap")
+    copy!(cm_get_cmap, matplotlib.pyplot."get_cmap")
     copy!(cm_register_cmap, matplotlib.colormaps."register")
 
     copy!(ScalarMappable, cm."ScalarMappable")

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -54,8 +54,8 @@ function init_colormaps()
 
     copy!(LinearSegmentedColormap, colorsm."LinearSegmentedColormap")
 
-    copy!(cm_get_cmap, matplotlib.pyplot."get_cmap")
-    copy!(cm_register_cmap, matplotlib.colormaps."register")
+    copy!(cm_get_cmap, haskey(plt, "get_cmap") ? plt."get_cmap" : cm."get_cmap")
+    copy!(cm_register_cmap, haskey(matplotlib.colormaps, "register") ? matplotlib.colormaps."register" : cm."register_cmap")
 
     copy!(ScalarMappable, cm."ScalarMappable")
     copy!(Normalize01, pycall(colorsm."Normalize",PyAny,vmin=0,vmax=1))

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -54,7 +54,7 @@ function init_colormaps()
 
     copy!(LinearSegmentedColormap, colorsm."LinearSegmentedColormap")
 
-    copy!(cm_get_cmap, cm."get_cmap")
+    copy!(cm_get_cmap, cm.ColormapRegistry."get_cmap")
     copy!(cm_register_cmap, cm."register_cmap")
 
     copy!(ScalarMappable, cm."ScalarMappable")

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -55,7 +55,7 @@ function init_colormaps()
     copy!(LinearSegmentedColormap, colorsm."LinearSegmentedColormap")
 
     copy!(cm_get_cmap, cm.ColormapRegistry."get_cmap")
-    copy!(cm_register_cmap, cm."register_cmap")
+    copy!(cm_register_cmap, matplotlib.colormaps."register")
 
     copy!(ScalarMappable, cm."ScalarMappable")
     copy!(Normalize01, pycall(colorsm."Normalize",PyAny,vmin=0,vmax=1))


### PR DESCRIPTION
Trying to fix #582 by using the new APIs in Matplotlib 3.9 (which was deprecated since 3.6). I am not sure is the wrapper functions on the PyPlot side should also be renamed. I have not tested this locally since I don't know how to smoothly switch matplotlib versions without affecting my current environment...