### PR TITLE
Version 2.12.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [compat]
-PyCall = "1.90"
-julia = "1"
-LaTeXStrings = "1"
 Colors = "0.9, 0.10, 0.11, 0.12, 1"
+LaTeXStrings = "1"
+PyCall = "1.90"
 VersionParsing = "1"
+julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PyPlot"
 uuid = "d330b81b-6aea-500a-939a-2ce795aea3ee"
-version = "2.11.2"
+version = "2.12.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"


### PR DESCRIPTION
Given #583, I think a minor bump might be warranted.

Presumably fixes doctest failures like this SnoopCompile one: https://github.com/timholy/SnoopCompile.jl/actions/runs/9759104755/job/26935099642?pr=386

I don't have merge privileges so someone else will need to handle this.