### PR TITLE
Update deprecated methods

### DIFF
--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -54,8 +54,8 @@ function init_colormaps()
 
     copy!(LinearSegmentedColormap, colorsm."LinearSegmentedColormap")
 
-    copy!(cm_get_cmap, haskey(plt, "get_cmap") ? plt."get_cmap" : cm."get_cmap")
-    copy!(cm_register_cmap, haskey(matplotlib.colormaps, "register") ? matplotlib.colormaps."register" : cm."register_cmap")
+    copy!(cm_get_cmap, hasproperty(plt, "get_cmap") ? plt."get_cmap" : cm."get_cmap")
+    copy!(cm_register_cmap, hasproperty(matplotlib.colormaps, "register") ? matplotlib.colormaps."register" : cm."register_cmap")
 
     copy!(ScalarMappable, cm."ScalarMappable")
     copy!(Normalize01, pycall(colorsm."Normalize",PyAny,vmin=0,vmax=1))


### PR DESCRIPTION
I noticed the following warning while using PyPlot:

```julia
┌ Warning: `haskey(o::PyObject, s::Union{Symbol, AbstractString})` is deprecated, use `hasproperty(o, s)` instead.
│   caller = init_colormaps() at colormaps.jl:57
└ @ PyPlot C:\Users\hyzho\.julia\packages\PyPlot\OOWfD\src\colormaps.jl:57
```

This PR updates the methods accordingly.